### PR TITLE
Update documentation for changes to premailer-rails3 repo, and fix typo in configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ Premailer integration
       end
     end
 
-If you're your running Rails 3, you may consider using [premailer-rails3](https://github.com/fphilipe/premailer-rails3). It will inline CSS, automatically create plain text emails, and requires almost no configuration.
+If you're your running Rails 3, you may consider using [premailer-rails](https://github.com/fphilipe/premailer-rails). It will inline CSS, automatically create plain text emails, and requires almost no configuration.
+
 
     RailsEmailPreview.setup do |config|
       config.before_render do |message|
-        PremailerRails::Hook.delivering_email(message)
+        Premailer::Rails::Hook.delivering_email(message)
       end
     end
 


### PR DESCRIPTION
Seems **premailer-rails3** is deprecated now so i'm using **premailer-rails** gem.  Updated docs to reflect this and fixed a typo in the docs for the configuration of premailer-rails integration.

This is a great little tool for WYSIWYG email design, nice and simple.
