### PR TITLE
change the premailerrails class syntax for configuration with premailer

### DIFF
--- a/config/initializers/rails_email_preview.rb
+++ b/config/initializers/rails_email_preview.rb
@@ -3,7 +3,7 @@ require 'rails_email_preview'
 #= Premailer
 #
 # # process preview with premailer-rails:
-# RailsEmailPreview.before_render { |message| Premailer::Rails::Hook.delivering_email(message) }
+# RailsEmailPreview.before_render { |message| PremailerRails::Hook.delivering_email(message) }
 # # process preview with actionmailer-inline-css:
 # RailsEmailPreview.before_render { |message| ActionMailer::InlineCssHook.delivering_email(message) }
 


### PR DESCRIPTION
this fixed my issues with premailer, I took it from our code with the older version of rails_email_preview. I got this to work locally. Issue fixed #11 
