### PR TITLE
fix for wrong 'preview_id' parameter value  for 'view' button in snippet...

### DIFF
--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -103,6 +103,7 @@ module RailsEmailPreview
         id_prefix = 'email-'
         return unless snippet && snippet.identifier && snippet.identifier.starts_with?(id_prefix)
         mailer_cl, act = snippet.identifier[id_prefix.length..-1].split('-')
+        act = act.sub(/_email\Z/, '') if act.end_with?('_email')
         { preview_id: "#{mailer_cl}_preview-#{act}",
           email_locale: snippet.site.locale }
       end


### PR DESCRIPTION
Hi, 
This is a fix for problem described below:

I noticed that there is a mismatch between two request while editing the email snippet and then trying to view it

Requests:
1.
Started GET "/emails/user_mailer_preview-welcome" 
Processing by RailsEmailPreview::EmailsController#show as HTML
  Parameters: {"preview_id"=>"user_mailer_preview-welcome"}

2.
Started GET "/emails/raw/user_mailer_preview-welcome_email?email_locale=en&part_type=text%2Fhtml"
Processing by RailsEmailPreview::EmailsController#show_body as HTML
  Parameters: {"email_locale"=>"en", "part_type"=>"text/html", "preview_id"=>"user_mailer_preview-welcome_email"}

In first, preview_id:
user_mailer_preview-welcome
in second, preview_id:
user_mailer_preview-welcome_email

This mismatch causes troubles  of course:
ActionController::RoutingError - Not Found:
  /rails_email_preview/app/controllers/rails_email_preview/emails_controller.rb:96:in `load_preview'
