### PR TITLE
Inline Attachments don't seem to work

### DIFF
--- a/app/controllers/rails_email_preview/emails_controller.rb
+++ b/app/controllers/rails_email_preview/emails_controller.rb
@@ -33,8 +33,7 @@ class RailsEmailPreview::EmailsController < ::RailsEmailPreview::ApplicationCont
   def show_attachment
     @mail = @preview.preview_mail
     attachment = @mail.attachments.find { |a| a.filename == "#{params[:filename]}.#{request.format.symbol}" }
-    filepath = File.join(RailsEmailPreview.attachments_dir, attachment.filename)
-    send_data File.read(filepath)
+    send_data attachment.body.raw_source
   end
 
   def test_deliver
@@ -68,6 +67,7 @@ class RailsEmailPreview::EmailsController < ::RailsEmailPreview::ApplicationCont
   def mail_body(preview, part_type, edit_links = (part_type == 'text/html'))
     RequestStore.store[:rep_edit_links] = true if edit_links
     mail = preview.preview_mail(true)
+    
     return "<pre id='raw_message'>#{html_escape(mail.to_s)}</pre>".html_safe if part_type == 'raw'
 
     body_part = if mail.multipart?
@@ -82,7 +82,7 @@ class RailsEmailPreview::EmailsController < ::RailsEmailPreview::ApplicationCont
       body_content = body_part.body.to_s
 
       mail.attachments.each do |attachment|
-        web_url = rails_email_preview.rep_raw_email_attachment_path(params[:preview_id], attachment.filename)
+        web_url = rails_email_preview.rep_raw_email_attachment_url(params[:preview_id], attachment.filename)
         body_content.gsub!(attachment.url, web_url)
       end
 

--- a/app/models/rails_email_preview/preview.rb
+++ b/app/models/rails_email_preview/preview.rb
@@ -15,25 +15,8 @@ module RailsEmailPreview
       %w(text/html text/plain raw)
     end
 
-    def process_attachments(mail)
-      attachments_dir = RailsEmailPreview.attachments_dir
-      
-      if mail.attachments.any?
-        FileUtils.mkdir_p(attachments_dir)
-        mail.attachments.each do |attachment|
-          filename = attachment.filename.gsub(/[^\w.]/, '_')
-          path = File.join(attachments_dir, filename)
-
-          unless File.exists?(path) # true if other parts have already been rendered
-            File.open(path, 'wb') { |f| f.write(attachment.body.raw_source) }
-          end
-        end
-      end
-    end
-
     def preview_mail(run_hooks = false)
       preview_class_name.constantize.new.send(preview_method).tap do |mail|
-        process_attachments(mail)
         RailsEmailPreview.run_before_render(mail, self) if run_hooks
       end
     end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -29,9 +29,6 @@ module RailsEmailPreview
   mattr_accessor :enable_send_email
   self.enable_send_email = true
 
-  mattr_accessor :attachments_dir
-  self.attachments_dir = File.join('tmp', 'rails_email_preview', 'attachments')
-
   # some easy visual settings
   mattr_accessor :style
   self.style = {


### PR DESCRIPTION
First of all, awesome gem. It's extremely helpful. It doesn't seem like it's able to display inline attachments, though.

In my mailer, I set an inline attachment:

``` ruby
def welcome(user)
  attachments.inline['logo.png'] = File.read(Rails.root.join('app/assets/images/logo.png'))
  mail(to: user.email, subject: 'Example Email')
end
```

In my view I display the attachment:

``` ruby
image_tag(attachments['logo.png'].url)
```

When I load up Rails Email Preview, I see this in the js console:

```
GET cid:537643989ad47_f68104fe889515@ray-desktop.mail net::ERR_UNKNOWN_URL_SCHEME 
```

When I send the email, everything works as expected, and the image displays. 
