### PR TITLE
Allow custom parameters to be passed when loading an email preview

### DIFF
--- a/app/controllers/rails_email_preview/emails_controller.rb
+++ b/app/controllers/rails_email_preview/emails_controller.rb
@@ -149,7 +149,7 @@ module RailsEmailPreview
     end
 
     def load_preview
-      @preview = ::RailsEmailPreview::Preview[params[:preview_id]] or raise ActionController::RoutingError.new('Not Found')
+      @preview = ::RailsEmailPreview::Preview[params[:preview_id], params] or raise ActionController::RoutingError.new('Not Found')
       @part_type = params[:part_type] || 'html'
     end
   end

--- a/app/models/rails_email_preview/preview.rb
+++ b/app/models/rails_email_preview/preview.rb
@@ -36,9 +36,15 @@ module RailsEmailPreview
       @group_name ||= preview_class_name.to_s.underscore.sub(/(_mailer)?_preview$/, '').humanize
     end
 
+    def set_variables(object, params)
+      setup_instance_variables(object, params)
+    end
+
     class << self
-      def find(email_id)
-        @by_id[email_id]
+      def find(email_id, params={})
+        preview = @by_id[email_id]
+        preview.set_variables(preview, params)
+        preview
       end
 
       alias_method :[], :find


### PR DESCRIPTION
I have a use case where I need to load user specific overrides in the preview so that the user can see their specific email changes. This goes around mocking the email data, but it is very helpful in my case.
