### PR TITLE
Change contraint on preview_id in routes

### DIFF
--- a/app/assets/stylesheets/rails_email_preview/_bootstrap.scss
+++ b/app/assets/stylesheets/rails_email_preview/_bootstrap.scss
@@ -366,8 +366,10 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.eot");
-  src: url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
+  src: url("/assets/bootstrap/glyphicons-halflings-regular.eot");
+  src: url("/assets/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("/assets/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("/assets/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("/assets/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
+//  src: url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.eot");
+//  src: url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
 }
 
 /* line 25, _glyphicons.scss */

--- a/app/assets/stylesheets/rails_email_preview/_bootstrap.scss
+++ b/app/assets/stylesheets/rails_email_preview/_bootstrap.scss
@@ -368,8 +368,6 @@ th {
   font-family: 'Glyphicons Halflings';
   src: url("/assets/bootstrap/glyphicons-halflings-regular.eot");
   src: url("/assets/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("/assets/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("/assets/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("/assets/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
-//  src: url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.eot");
-//  src: url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("/stylesheets/fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg");
 }
 
 /* line 25, _glyphicons.scss */

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -41,8 +41,8 @@ ruby:
         // Do not mess with identifier
         $('[data-slug]').removeAttr('data-slug');
         
-        // Handle cancel link
-        $('input[type=submit]').next('a').attr('href', '#{back_url}')
+        // Remove cancel link
+        $('input[type=submit]').next('a').remove();
       });
 
       // Schedule headers view refresh on next load

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -42,7 +42,7 @@ ruby:
         $('[data-slug]').removeAttr('data-slug');
         
         // Handle cancel link
-        $('input[type=submit]').attr('href', '#{back_url}')
+        $('input[type=submit]').next('a').attr('href', '#{back_url}')
       });
 
       // Schedule headers view refresh on next load

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -4,7 +4,7 @@ ruby:
   snippet = @snippet || (adapter.cms_snippet_class === @record && @record)
   if snippet && (p = adapter.rep_email_params_from_snippet(snippet))
     show_url = rails_email_preview.rep_raw_email_url(p)
-    back_url = rails_email_preview.rep_email_url(p)
+    back_url = rails_email_preview.rep_preview_email_url(p, layout: 'hidden')
   end
   customize_form = show_url.present? || snippet && !snippet.persisted?
 

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -4,7 +4,7 @@ ruby:
   snippet = @snippet || (adapter.cms_snippet_class === @record && @record)
   if snippet && (p = adapter.rep_email_params_from_snippet(snippet))
     show_url = rails_email_preview.rep_raw_email_url(p)
-    back_url = rails_email_preview.rep_email_url(p, layout: 'hidden')
+    back_url = rails_email_preview.rep_email_url(p.merge(layout: 'hidden'))
   end
   customize_form = show_url.present? || snippet && !snippet.persisted?
 

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -4,6 +4,7 @@ ruby:
   snippet = @snippet || (adapter.cms_snippet_class === @record && @record)
   if snippet && (p = adapter.rep_email_params_from_snippet(snippet))
     show_url = rails_email_preview.rep_raw_email_url(p)
+    back_url = rails_email_preview.rep_email_url(p)
   end
   customize_form = show_url.present? || snippet && !snippet.persisted?
 
@@ -39,6 +40,9 @@ ruby:
 
         // Do not mess with identifier
         $('[data-slug]').removeAttr('data-slug');
+        
+        // Handle cancel link
+        $('input[type=submit]').attr('href', '#{back_url}')
       });
 
       // Schedule headers view refresh on next load

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -24,7 +24,7 @@ ruby:
           if (!/\?/.test(showUrl)) showUrl += '?';
           showUrl = showUrl.replace(/\?.*$/, parentParams);
           $('.page-header h2').html(
-            "#{t '.edit_email'}" + " <a class='btn btn-primary pull-right' href='" + showUrl + "'>#{t '.view_link'}</a>");
+            "#{t '.edit_email'}" + " <a class='btn btn-primary pull-right' style='margin-right: 3px;' href='" + showUrl + "'>#{t '.view_link'}</a>");
         }
 
         // Snippet form:

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -4,7 +4,7 @@ ruby:
   snippet = @snippet || (adapter.cms_snippet_class === @record && @record)
   if snippet && (p = adapter.rep_email_params_from_snippet(snippet))
     show_url = rails_email_preview.rep_raw_email_url(p)
-    back_url = rails_email_preview.rep_preview_email_url(p, layout: 'hidden')
+    back_url = rails_email_preview.rep_email_url(p, layout: 'hidden')
   end
   customize_form = show_url.present? || snippet && !snippet.persisted?
 

--- a/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
+++ b/app/views/integrations/cms/_customize_cms_for_rails_email_preview.html.slim
@@ -24,7 +24,7 @@ ruby:
           if (!/\?/.test(showUrl)) showUrl += '?';
           showUrl = showUrl.replace(/\?.*$/, parentParams);
           $('.page-header h2').html(
-            "#{t '.edit_email'}" + " <a class='btn btn-primary' href='" + showUrl + "'>#{t '.view_link'}</a>");
+            "#{t '.edit_email'}" + " <a class='btn btn-primary pull-right' href='" + showUrl + "'>#{t '.view_link'}</a>");
         }
 
         // Snippet form:

--- a/app/views/rails_email_preview/emails/index.html.slim
+++ b/app/views/rails_email_preview/emails/index.html.slim
@@ -2,20 +2,19 @@ ruby:
   list     = @list
   previews = @previews
 
-h1 = t '.list_title'
+div class="page-header"
+  h2 = t('.list_title')
 
-= with_index_hook :list do
-  div class=rep_row_class
-    - list.columns do |groups|
-      div class=rep_col_class(6)
-        - groups.each do |title, group_previews|
-          h2 = title
-          div class=rep_style[:list_group_class]
-            - group_previews.each do |p|
-              a class=rep_style[:list_group_item_class] href=rails_email_preview.rep_email_path(preview_id: p.id, email_locale: @email_locale)
-                = p.method_name
-hr
-p.text-center.text-small.text-info
-  | #{t 'rep.base.email', count: previews.length} #{t 'rep.base.in'} #{t 'rep.base.mailer', count: list.groups.length }
-  br
-  a href="https://github.com/glebm/rails_email_preview" target='_blank' REP #{RailsEmailPreview::VERSION}
+- list.columns do |groups|
+  - groups.each do |title, group_previews|
+    div class="table-responsive"
+      table class="table table-hover table-bordered"
+        thead
+          tr
+            th = title
+        tbody
+          - group_previews.each do |p|
+            tr
+              td
+                a href=rails_email_preview.rep_email_path(preview_id: p.id, email_locale: @email_locale)
+                  = t(p.method_name, default: p.method_name)

--- a/app/views/rails_email_preview/emails/show.html.slim
+++ b/app/views/rails_email_preview/emails/show.html.slim
@@ -1,9 +1,5 @@
-.rep-email-show#email-show
-  = with_show_hook :breadcrumb do
-    ol.breadcrumb
-      = with_show_hook :breadcrumb_content do
-        li: a href=rails_email_preview.rep_emails_path(email_locale: @email_locale) = t '.breadcrumb_list'
-        li.active: a href=(request.path) = @preview.name
+div class="page-header"
+  h2 = @preview.name
 
   = with_show_hook :headers_and_nav do
     = render 'rails_email_preview/emails/headers_and_nav'

--- a/app/views/rails_email_preview/emails/show.html.slim
+++ b/app/views/rails_email_preview/emails/show.html.slim
@@ -1,4 +1,4 @@
-unless params[:layout] == 'hidden'
+- unless params[:layout] == 'hidden'
   div class="page-header"
     h2 = @preview.name
 
@@ -8,6 +8,6 @@ unless params[:layout] == 'hidden'
     = with_show_hook :email_body do
       / actual email content, rendered in an iframe to prevent browser styles from interfering
       = render 'rails_email_preview/emails/email_iframe'
-else
+- else
   = with_show_hook :email_body do
     = render 'rails_email_preview/emails/email_iframe'

--- a/app/views/rails_email_preview/emails/show.html.slim
+++ b/app/views/rails_email_preview/emails/show.html.slim
@@ -1,9 +1,13 @@
-div class="page-header"
-  h2 = @preview.name
+unless params[:layout] == 'hidden'
+  div class="page-header"
+    h2 = @preview.name
 
-  = with_show_hook :headers_and_nav do
-    = render 'rails_email_preview/emails/headers_and_nav'
+    = with_show_hook :headers_and_nav do
+      = render 'rails_email_preview/emails/headers_and_nav'
 
+    = with_show_hook :email_body do
+      / actual email content, rendered in an iframe to prevent browser styles from interfering
+      = render 'rails_email_preview/emails/email_iframe'
+else
   = with_show_hook :email_body do
-    / actual email content, rendered in an iframe to prevent browser styles from interfering
     = render 'rails_email_preview/emails/email_iframe'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -42,6 +42,7 @@ de:
     cms:
       customize_cms_for_rails_email_preview:
         edit_email: E-Mail bearbeiten
+        edit_email_html: '<i class="glyphicon glyphicon-pencil"></i>&nbsp;E-Mail bearbeiten'
         view_link: Anzeigen
       errors:
         site_missing: Bitte erstellen Sie eine CMS-Website für %{locale} zuerst. Bei der Verwendung von mehreren Gebietsschemas sollte der Standort gespiegelt werden.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -31,7 +31,7 @@ de:
   rails_email_preview:
     emails:
       index:
-        list_title: Anwendungs E-Mails
+        list_title: E-Mails
       show:
         breadcrumb_list: E-Mails
       send_form:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -42,7 +42,6 @@ de:
     cms:
       customize_cms_for_rails_email_preview:
         edit_email: E-Mail bearbeiten
-        edit_email_html: '<i class="glyphicon glyphicon-pencil"></i>&nbsp;E-Mail bearbeiten'
         view_link: Anzeigen
       errors:
         site_missing: Bitte erstellen Sie eine CMS-Website für %{locale} zuerst. Bei der Verwendung von mehreren Gebietsschemas sollte der Standort gespiegelt werden.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
       in: in
       loading: Loading...
     test_deliver:
-      no_delivery_method: Please set 'config.action_mailer.delivery_method' to send emails in '%{environment}' environment
+      no_delivery_method: "Please set 'config.action_mailer.delivery_method' to send emails in '%{environment}' environment"
       provide_email: Send to which address?
       sent_notice: Sent to %{address} via %{delivery_method}
     errors:
@@ -44,4 +44,5 @@ en:
         site_missing: Please create a CMS site for %{locale} first. When using multiple locales the site should be Mirrored.
       customize_cms_for_rails_email_preview:
         edit_email: Editing email
+        edit_email_html: '<i class="glyphicon glyphicon-pencil"></i>&nbsp;edit Email'
         view_link: View

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,5 +44,4 @@ en:
         site_missing: Please create a CMS site for %{locale} first. When using multiple locales the site should be Mirrored.
       customize_cms_for_rails_email_preview:
         edit_email: Editing email
-        edit_email_html: '<i class="glyphicon glyphicon-pencil"></i>&nbsp;edit Email'
         view_link: View

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
   rails_email_preview:
     emails:
       index:
-        list_title: Application Emails
+        list_title: Emails
       show:
         breadcrumb_list: Emails
       send_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ RailsEmailPreview::Engine.routes.draw do
           constraints: {email_locale: /#{I18n.available_locales.map(&Regexp.method(:escape)) * '|'}/},
           defaults: {email_locale: I18n.default_locale.to_s} do
       get '/' => :index, as: :rep_emails
-      scope path: ':preview_id', constraints: {preview_id: /\w*\/?\w+-\w+/} do
+      scope path: ':preview_id', constraints: {preview_id: /\w+-\w+/} do
         scope '(:part_type)',
               constraints: {part_type: /html|plain|raw/},
               defaults: {part_type: 'html'} do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ RailsEmailPreview::Engine.routes.draw do
           constraints: {email_locale: /#{I18n.available_locales.map(&Regexp.method(:escape)) * '|'}/},
           defaults: {email_locale: I18n.default_locale.to_s} do
       get '/' => :index, as: :rep_emails
-      scope path: ':preview_id', constraints: {preview_id: /\w+\/\w+-\w+/} do
+      scope path: ':preview_id', constraints: {preview_id: /\w*\/?\w+-\w+/} do
         scope '(:part_type)',
               constraints: {part_type: /html|plain|raw/},
               defaults: {part_type: 'html'} do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ RailsEmailPreview::Engine.routes.draw do
           constraints: {email_locale: /#{I18n.available_locales.map(&Regexp.method(:escape)) * '|'}/},
           defaults: {email_locale: I18n.default_locale.to_s} do
       get '/' => :index, as: :rep_emails
-      scope path: ':preview_id', constraints: {preview_id: /\w+-\w+/} do
+      scope path: ':preview_id', constraints: {preview_id: /\w+\/\w+-\w+/} do
         scope '(:part_type)',
               constraints: {part_type: /html|plain|raw/},
               defaults: {part_type: 'html'} do

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -86,6 +86,6 @@ module RailsEmailPreview
   # = Editing settings
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
-  self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email')
+  self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
   mattr_accessor :edit_link_style
 end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -86,7 +86,7 @@ module RailsEmailPreview
   # = Editing settings
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
-  self.edit_link_text = '✎ Edit Text'
+  self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email')
   mattr_accessor :edit_link_style
   self.edit_link_style = <<-CSS.strip.gsub(/\n+/m, ' ')
   display: block;

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -86,6 +86,5 @@ module RailsEmailPreview
   # = Editing settings
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
-  self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
   mattr_accessor :edit_link_style
 end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -86,6 +86,7 @@ module RailsEmailPreview
   # = Editing settings
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
+  self.edit_link_text = '✎'
   mattr_accessor :edit_link_style
   self.edit_link_style = <<-CSS.strip.gsub(/\n+/m, ' ')
   -webkit-appearance: none;
@@ -148,5 +149,7 @@ module RailsEmailPreview
   white-space: nowrap;
   word-spacing: 0px;
   writing-mode: lr-tb;
+  text-decoration: none;
+  float: right;
   CSS
 end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -86,6 +86,6 @@ module RailsEmailPreview
   # = Editing settings
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
-  self.edit_link_text = I18n.t('rep.integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
+  self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
   mattr_accessor :edit_link_style
 end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -86,6 +86,6 @@ module RailsEmailPreview
   # = Editing settings
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
-  self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
+  self.edit_link_text = I18n.t('rep.integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
   mattr_accessor :edit_link_style
 end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -88,14 +88,4 @@ module RailsEmailPreview
   mattr_accessor :edit_link_text
   self.edit_link_text = I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email')
   mattr_accessor :edit_link_style
-  self.edit_link_style = <<-CSS.strip.gsub(/\n+/m, ' ')
-  display: block;
-  font-family: Monaco, Helvetica, sans-serif;
-  color: #7a4b8a;
-  border: 2px dashed #7a4b8a;
-  font-size: 20px;
-  padding: 8px 12px;
-  margin-top: 0.6em;
-  margin-bottom: 0.6em;
-  CSS
 end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -87,4 +87,66 @@ module RailsEmailPreview
   # edit link is rendered inside an iframe, so these options are provided for simple styling
   mattr_accessor :edit_link_text
   mattr_accessor :edit_link_style
+  self.edit_link_style = <<-CSS.strip.gsub(/\n+/m, ' ')
+  -webkit-appearance: none;
+  -webkit-box-shadow: rgba(255, 255, 255, 0.14902) 0px 1px 0px 0px inset, rgba(0, 0, 0, 0.0745098) 0px 1px 1px 0px;
+  -webkit-rtl-ordering: logical;
+  -webkit-user-select: none;
+  -webkit-writing-mode: horizontal-tb;
+  background-color: rgb(255, 255, 255);
+  background-image: linear-gradient(rgb(255, 255, 255) 0px, rgb(224, 224, 224) 100%);
+  background-repeat: repeat-x;
+  border-bottom-color: rgb(204, 204, 204);
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-image-outset: 0px;
+  border-image-repeat: stretch;
+  border-image-slice: 100%;
+  border-image-source: none;
+  border-image-width: 1;
+  border-left-color: rgb(204, 204, 204);
+  border-left-style: solid;
+  border-left-width: 1px;
+  border-right-color: rgb(204, 204, 204);
+  border-right-style: solid;
+  border-right-width: 1px;
+  border-top-color: rgb(204, 204, 204);
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-top-style: solid;
+  border-top-width: 1px;
+  box-shadow: rgba(255, 255, 255, 0.14902) 0px 1px 0px 0px inset, rgba(0, 0, 0, 0.0745098) 0px 1px 1px 0px;
+  box-sizing: border-box;
+  color: rgb(51, 51, 51);
+  cursor: pointer;
+  display: inline-block;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: normal;
+  height: 34px;
+  letter-spacing: normal;
+  line-height: 20px;
+  margin-bottom: 5px;
+  margin-left: 0px;
+  margin-right: 0px;
+  margin-top: 5px;
+  padding-bottom: 6px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  text-align: center;
+  text-indent: 0px;
+  text-shadow: rgb(255, 255, 255) 0px 1px 0px;
+  text-transform: none;
+  touch-action: manipulation;
+  vertical-align: middle;
+  white-space: nowrap;
+  word-spacing: 0px;
+  writing-mode: lr-tb;
+  CSS
 end

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -101,8 +101,7 @@ module RailsEmailPreview
 
       def cms_edit_email_snippet_link(path)
         link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
-          RailsEmailPreview.edit_link_text
-          content_tag :i, nil, class: 'glyphicon glyphicon-pencil'
+          RailsEmailPreview.edit_link_text + content_tag(:i, nil, class: 'glyphicon glyphicon-pencil')
         end
       end
 

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -101,7 +101,7 @@ module RailsEmailPreview
 
       def cms_edit_email_snippet_link(path)
         link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
-          RailsEmailPreview.edit_link_text
+          RailsEmailPreview.edit_link_text.try(:html_safe)
         end
       end
 

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -100,7 +100,8 @@ module RailsEmailPreview
       end
 
       def cms_edit_email_snippet_link(path)
-        link_to(RailsEmailPreview.edit_link_text, path, style: RailsEmailPreview.edit_link_style.html_safe, class: 'btn btn-default pull-right') do
+        link_to path, style: RailsEmailPreview.edit_link_style.html_safe, class: 'btn btn-default pull-right' do
+          RailsEmailPreview.edit_link_text
           content_tag :i, class: 'glyphicon glyphicon-pencil'
         end
       end

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -100,9 +100,7 @@ module RailsEmailPreview
       end
 
       def cms_edit_email_snippet_link(path)
-        link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
-          I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html').html_safe
-        end
+        link_to(RailsEmailPreview.edit_link_text, path, style: RailsEmailPreview.edit_link_style.html_safe)
       end
 
       def self.rep_email_params_from_snippet(snippet)

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -102,7 +102,7 @@ module RailsEmailPreview
       def cms_edit_email_snippet_link(path)
         link_to path, style: RailsEmailPreview.edit_link_style.html_safe, class: 'btn btn-default pull-right' do
           RailsEmailPreview.edit_link_text
-          content_tag :i, class: 'glyphicon glyphicon-pencil'
+          content_tag :i, nil, class: 'glyphicon glyphicon-pencil'
         end
       end
 

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -71,7 +71,7 @@ module RailsEmailPreview
                       send :"new_#{cms_admin_site_snippet_route}_path", p
                     end
         <<-HTML.strip.html_safe
-          <table class='rep-edit-link'><tr><td>
+          <table class='rep-edit-link' style="width: 100%;"><tr><td>
             #{cms_edit_email_snippet_link(edit_path)}
           </td></tr></table>
         HTML

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -61,7 +61,7 @@ module RailsEmailPreview
                         }
                         p[:snippet][:label] = default_snippet.label unless snippet.label.present?
                       end
-                      send :"edit_#{cms_admin_site_snippet_route}_path", p
+                      send :"edit_#{cms_admin_site_snippet_route}_url", p
                     else
                       p[:snippet] = {
                           label:        snippet.label,

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -9,7 +9,7 @@ module RailsEmailPreview
       # ModerationMailer#approve -> "moderation_mailer-approve"
       def cms_email_id
         mailer = respond_to?(:controller) ? controller : self
-        "#{mailer.class.name.underscore}-#{action_name}"
+        "#{mailer.class.name.underscore.gsub('/','_')}-#{action_name}"
       end
 
       # @param [Hash] interpolation subject interpolation values

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -101,7 +101,7 @@ module RailsEmailPreview
 
       def cms_edit_email_snippet_link(path)
         link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
-          I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
+          I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html').html_safe
         end
       end
 

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -100,7 +100,9 @@ module RailsEmailPreview
       end
 
       def cms_edit_email_snippet_link(path)
-        link_to(RailsEmailPreview.edit_link_text, path, style: RailsEmailPreview.edit_link_style.html_safe)
+        link_to(RailsEmailPreview.edit_link_text, path, style: RailsEmailPreview.edit_link_style.html_safe, class: 'btn btn-default pull-right') do
+          content_tag :i, class: 'glyphicon glyphicon-pencil'
+        end
       end
 
       def self.rep_email_params_from_snippet(snippet)

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -101,7 +101,7 @@ module RailsEmailPreview
 
       def cms_edit_email_snippet_link(path)
         link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
-          RailsEmailPreview.edit_link_text + content_tag(:i, nil, class: 'glyphicon glyphicon-pencil')
+          RailsEmailPreview.edit_link_text
         end
       end
 

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -100,7 +100,7 @@ module RailsEmailPreview
       end
 
       def cms_edit_email_snippet_link(path)
-        link_to path, style: RailsEmailPreview.edit_link_style.html_safe, class: 'btn btn-default pull-right' do
+        link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
           RailsEmailPreview.edit_link_text
           content_tag :i, nil, class: 'glyphicon glyphicon-pencil'
         end

--- a/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
+++ b/lib/rails_email_preview/integrations/comfortable_mexica_sofa.rb
@@ -101,7 +101,7 @@ module RailsEmailPreview
 
       def cms_edit_email_snippet_link(path)
         link_to path, style: RailsEmailPreview.edit_link_style.try(:html_safe), class: 'btn btn-default pull-right' do
-          RailsEmailPreview.edit_link_text.try(:html_safe)
+          I18n.t('integrations.cms.customize_cms_for_rails_email_preview.edit_email_html')
         end
       end
 


### PR DESCRIPTION
We ran into an issue when using [Comfortable Mexican Sofa](https://github.com/comfy/comfortable-mexican-sofa) together with Rails Email Preview with Devise emails.

The preview_id's of our mailers become something like 'devise/mailer', which causes some links to break. We changed the "cms_email_id" accordingly to actually turn '/' into '_', which seems to work fine.

I'm not sure if this is a proper fix, but I hope it useful...

Thanks for this great gem btw :)