### PR TITLE
Rename method_name to humanized_method_name

### DIFF
--- a/app/models/rails_email_preview/preview.rb
+++ b/app/models/rails_email_preview/preview.rb
@@ -32,6 +32,7 @@ module RailsEmailPreview
       @action_name ||= preview_method.to_s.humanize
     end
 
+    # @deprecated {#method_name} is deprecated and will be removed in v3
     alias_method :method_name, :humanized_method_name
 
     def group_name
@@ -42,7 +43,7 @@ module RailsEmailPreview
       def find(email_id)
         @by_id[email_id]
       end
-      
+
       alias_method :[], :find
 
       attr_reader :all

--- a/app/models/rails_email_preview/preview.rb
+++ b/app/models/rails_email_preview/preview.rb
@@ -25,12 +25,14 @@ module RailsEmailPreview
     end
 
     def name
-      @name ||= "#{group_name}: #{method_name}"
+      @name ||= "#{group_name}: #{humanized_method_name}"
     end
 
-    def method_name
+    def humanized_method_name
       @action_name ||= preview_method.to_s.humanize
     end
+
+    alias_method :method_name, :humanized_method_name
 
     def group_name
       @group_name ||= preview_class_name.to_s.underscore.gsub('/', ': ').sub(/(_mailer)?_preview$/, '').humanize
@@ -40,7 +42,7 @@ module RailsEmailPreview
       def find(email_id)
         @by_id[email_id]
       end
-
+      
       alias_method :[], :find
 
       attr_reader :all

--- a/app/views/rails_email_preview/emails/index.html.erb
+++ b/app/views/rails_email_preview/emails/index.html.erb
@@ -16,7 +16,7 @@
               <% group_previews.each do |p| %>
                 <a class="<%= rep_style[:list_group_item_class] %>"
                    href="<%= rails_email_preview.rep_email_path(preview_id: p.id, email_locale: @email_locale) %>">
-                  <%= p.method_name %>
+                  <%= p.humanized_method_name %>
                 </a>
               <% end %>
             </div>

--- a/shared.gemfile
+++ b/shared.gemfile
@@ -14,11 +14,11 @@ if ENV['TRAVIS']
 else
   group :test, :development do
     gem 'byebug', platform: :mri_21, require: false
+    gem 'coffee-rails'
   end
 
   group :development do
     gem 'puma'
-    gem 'coffee-script'
   end
 
   group :test do

--- a/shared.gemfile
+++ b/shared.gemfile
@@ -18,6 +18,7 @@ else
 
   group :development do
     gem 'puma'
+    gem 'coffee-script'
   end
 
   group :test do


### PR DESCRIPTION
The output of method_name is supposed to be something that can be used with
send. a method like this already exists like preview_method_name

To not break API compatibility an alias for the old method is provided as well.