### PR TITLE
Fix compatibility with ruby < 2.2 and ruby > 1.9.3

### DIFF
--- a/app/views/layouts/rails_email_preview/application.html.erb
+++ b/app/views/layouts/rails_email_preview/application.html.erb
@@ -2,11 +2,11 @@
 <html>
 <head>
   <title><%= t('.head_title') %></title>
-  <%= stylesheet_link_tag 'rails_email_preview/application', 'data-turbolinks-track': 'reload' %>
+  <%= stylesheet_link_tag 'rails_email_preview/application', 'data-turbolinks-track' => 'reload' %>
   <%= csrf_meta_tag %>
   <%= csp_meta_tag if RailsEmailPreview.rails_supports_csp_nonce? %>
   <%= javascript_include_tag 'rails_email_preview/application',
-                             'data-turbolinks-track': 'reload' %>
+                             'data-turbolinks-track' => 'reload' %>
   <%= favicon_link_tag 'rails_email_preview/favicon.png' %>
   <%= yield(:head) %>
 </head>


### PR DESCRIPTION
### Motivation

Issue: [https://github.com/glebm/rails_email_preview/issues/83](https://github.com/glebm/rails_email_preview/issues/83)
After tag `2.2.0` release, its becomes no longer compatibly with Rails 4.2, due to the use of ` : ` notation with a string as key, not supported until Ruby 2.2.

### Solution

- [x] Switch `:` notation by HashRocket.