### PR TITLE
Rename respond_to? method to respond_to_missing? to fix warning

### DIFF
--- a/lib/rails_email_preview/main_app_route_delegator.rb
+++ b/lib/rails_email_preview/main_app_route_delegator.rb
@@ -8,7 +8,7 @@ module RailsEmailPreview::MainAppRouteDelegator
     end
   end
 
-  def respond_to?(method)
+  def respond_to_missing?(method)
     super || main_app_route_method?(method)
   end
 


### PR DESCRIPTION
The call to `respond_to?` in the route delegator started throwing copious warnings into my logs when I moved to Ruby 3.0.0; this change fixes it.