### PR TITLE
replacing sassc with dartsass-sprockets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,31 +9,32 @@ jobs:
     strategy:
       matrix:
         include:
-          - ruby_version: '2.7'
-            gemfile: rails_7_0
+          - ruby_version: '3.3'
+            gemfile: rails_7_1
             upload_coverage: true
-          - ruby_version: '2.5'
+          - ruby_version: '3.2'
+            gemfile: rails_7_1
+          # - ruby_version: '3.1'
+          #   gemfile: rails_7_1
+          - ruby_version: '3.3'
+            gemfile: rails_7_0
+          - ruby_version: '3.3'
             gemfile: rails_6_1
-          - ruby_version: '2.3'
-            gemfile: rails_5_0
-          - ruby_version: '2.3'
-            gemfile: rails_4_2
-            bundler: '1'
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      CI: 1
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: "Determine whether to upload coverage"
         if: ${{ env.CC_TEST_REPORTER_ID && matrix.upload_coverage }}
         run: echo COVERAGE=1 >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby_version }} and ${{ matrix.gemfile }}.gemfile
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler: ${{ matrix.bundler || 'Gemfile.lock' }}
           bundler-cache: true
+          cache-version: 1000
       - name: Run tests
         if: ${{ !env.COVERAGE }}
         run: bundle exec rspec --format d
@@ -47,11 +48,11 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/gemfiles/i18n-tasks.gemfile
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby and i18n-tasks.gemfile
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
       - name: Run i18n-tasks
         run: bundle exec i18n-tasks health

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+* Remove explicit dependency on `sassc-rails`. Allow the use of this gem with either:
+  `dartsass-sprockets`, `sassc-rails`, `dartsass-rails`, or `cssbundling-rails`
+* Drop support for EOL ruby and rails versions (rails >6.1, ruby >3.1)
+
 ## v2.2.3
 
 * Fixes Rails 7 compatibility.

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,7 @@ gemspec
 gem 'rails'
 gem 'i18n-tasks'
 
+# For development; when running as a library, you can pick your own sass compiler
+gem 'dartsass-sprockets'
+
 eval_gemfile './shared.gemfile'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,4 @@ gemspec
 gem 'rails'
 gem 'i18n-tasks'
 
-# For development; when running as a library, you can pick your own sass compiler
-gem 'dartsass-sprockets'
-
 eval_gemfile './shared.gemfile'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rails Email Preview [![Build Status][badge-ci]][ci] [![Test Coverage][coverage-badge]][coverage] [![Code Climate][codeclimate-badge]][codeclimate] [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/glebm/rails_email_preview?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Preview email in the browser with this Rails engine. Compatible with Rails 4.2+.
+Preview email in the browser with this Rails engine. Compatible with Rails 6.1+.
 
 An email review:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Add [![Gem Version][gem-badge]][gem] to Gemfile:
 gem 'rails_email_preview', '~> 2.2.3'
 ```
 
+This gem requires a Sass engine, please ensure you have **one** of these gems in your Gemfile:
+- [`dartsass-sprockets`](https://github.com/tablecheck/dartsass-sprockets): Dart Sass engine, recommended but only works for Ruby 2.6+ and Rails 5+
+- [`dartsass-rails`](https://github.com/rails/dartsass-rails): Dart Sass engine, recommended for Rails projects that use Propshaft
+- [`cssbundling-rails`](https://github.com/rails/cssbundling-rails): External Sass engine
+- [`sassc-rails`](https://github.com/sass/sassc-rails): SassC engine, deprecated but compatible with Ruby 2.3+ and Rails 4
+
 Add an initializer and the routes:
 
 ```console

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -5,7 +5,25 @@ require 'rails_email_preview/version'
 require 'rails_email_preview/delivery_handler'
 require 'rails_email_preview/view_hooks'
 
-require 'dartsass-sprockets'
+# sass engine loader
+begin
+  require 'dartsass-sprockets'
+rescue LoadError
+  begin
+    require 'sassc-rails'
+  rescue LoadError
+    begin
+      require 'dartsass-rails'
+    rescue LoadError
+      begin
+        require 'cssbundling-rails'
+      rescue LoadError
+        raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies.")
+      end
+    end
+  end
+end
+
 require 'request_store'
 require 'turbolinks'
 require 'pathname'

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -18,7 +18,7 @@ rescue LoadError
       begin
         require 'cssbundling-rails'
       rescue LoadError
-        raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies.")
+        raise LoadError.new("rails_email_preview requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies.")
       end
     end
   end

--- a/lib/rails_email_preview.rb
+++ b/lib/rails_email_preview.rb
@@ -5,7 +5,7 @@ require 'rails_email_preview/version'
 require 'rails_email_preview/delivery_handler'
 require 'rails_email_preview/view_hooks'
 
-require 'sassc-rails'
+require 'dartsass-sprockets'
 require 'request_store'
 require 'turbolinks'
 require 'pathname'

--- a/rails_email_preview.gemspec
+++ b/rails_email_preview.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'dartsass-sprockets'
   s.add_dependency 'turbolinks'
   s.add_dependency 'request_store'
 

--- a/rails_email_preview.gemspec
+++ b/rails_email_preview.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     s.metadata = { 'issue_tracker' => 'https://github.com/glebm/rails_email_preview' }
   end
 
-  s.add_dependency 'rails', '>= 4.2'
+  s.add_dependency 'rails', '>= 6.1'
   s.add_dependency 'turbolinks'
   s.add_dependency 'request_store'
 

--- a/rails_email_preview.gemspec
+++ b/rails_email_preview.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'sassc-rails', '>= 2.0.0'
+  s.add_dependency 'dartsass-sprockets'
   s.add_dependency 'turbolinks'
   s.add_dependency 'request_store'
 

--- a/shared.gemfile
+++ b/shared.gemfile
@@ -14,3 +14,6 @@ if ENV['COVERAGE']
     gem 'simplecov', require: false
   end
 end
+
+# For development/testing; when running as a library, you can pick your own sass compiler
+gem 'dartsass-sprockets'

--- a/spec/gemfiles/rails_4_2.gemfile
+++ b/spec/gemfiles/rails_4_2.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../..'
-eval_gemfile '../../shared.gemfile'
-
-gem 'rails', '~> 4.2.0'

--- a/spec/gemfiles/rails_5_2.gemfile
+++ b/spec/gemfiles/rails_5_2.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../..'
-eval_gemfile '../../shared.gemfile'
-
-gem 'rails', '~> 5.2.1'
-

--- a/spec/gemfiles/rails_7_1.gemfile
+++ b/spec/gemfiles/rails_7_1.gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 gemspec path: '../..'
 eval_gemfile '../../shared.gemfile'
 
-gem 'rails', '~> 5.0.2'
+gem 'rails', '~> 7.1'
+


### PR DESCRIPTION
[sassc is deprecated](https://github.com/sass/sassc-ruby/issues/220). Replacing sassc with dart-sass is the simplest and most straightforward methodology to keep using sass. The gem dartsass-sprockets provides a drop-in replacement implementing almost everything that sassc-rails offered utilizing the same namespace and method signatures.

There are several deprecation errors that needs to be addressed with the newer version of sass, but it would be good to upgrade to the latest version of the library.

These errors can be addressed in a future PR.

Deprecation errors:

```
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/_default.sass 60:17   @import
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/application.scss 1:9  root stylesheet
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($rep-grid-gutter, -2) or calc($rep-grid-gutter / -2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
61 │   margin-right: ($rep-grid-gutter / -2)
   │                  ^^^^^^^^^^^^^^^^^^^^^
   ╵
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/_default.sass 61:18   @import
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/application.scss 1:9  root stylesheet
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($rep-grid-gutter, 2) or calc($rep-grid-gutter / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
67 │   padding-right: ($rep-grid-gutter / 2)
   │                   ^^^^^^^^^^^^^^^^^^^^
   ╵
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/_default.sass 67:19   @import
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/application.scss 1:9  root stylesheet
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($rep-grid-gutter, 2) or calc($rep-grid-gutter / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
68 │   padding-left: ($rep-grid-gutter / 2)
   │                  ^^^^^^^^^^^^^^^^^^^^
   ╵
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/_default.sass 68:18   @import
    /usr/local/bundle/bundler/gems/rails_email_preview-0babc0ff21e4/app/assets/stylesheets/rails_email_preview/application.scss 1:9  root stylesheet
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($col, 12) or calc($col / 12)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
75 │       width: percentage($col / 12)
   │                         ^^^^^^^^^
   ╵
```