### PR TITLE
Fix preview link in show to use full path

### DIFF
--- a/app/views/rails_email_preview/emails/show.html.erb
+++ b/app/views/rails_email_preview/emails/show.html.erb
@@ -6,7 +6,7 @@
         <%= with_show_hook :breadcrumb_content do %>
           <li class="rep--breadcrumbs__breadcrumb">
             <a href="<%= rails_email_preview.rep_emails_path(email_locale: @email_locale) %>"><%= t '.breadcrumb_list' %></a>
-          </li><li class="rep--breadcrumbs__breadcrumb-active"><a href="<%= request.path %>"><%= @preview.name %></a></li>
+          </li><li class="rep--breadcrumbs__breadcrumb-active"><a href="<%= request.fullpath %>"><%= @preview.name %></a></li>
         <% end %>
       </ol>
     <% end %>


### PR DESCRIPTION
Use `request.fullpath` instead of `request.path` in preview link. 
Currently, `request.path` is used which does not include request params when user tries to open preview from the URL provided within mailer preview. This change makes sure all parameters are passed.